### PR TITLE
Add @bigtest/react docs

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,7 +6,8 @@ activate :directory_indexes
 activate :formatting_helpers
 activate :api_docs, packages: {
   'convergence' => '@bigtest/convergence',
-  'interactor' => '@bigtest/interactor'
+  'interactor' => '@bigtest/interactor',
+  'react' => '@bigtest/react'
 }
 
 activate :autoprefixer do |prefix|

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@babel/preset-env": "^7.0.0-beta.0",
     "@bigtest/convergence": "latest",
     "@bigtest/interactor": "latest",
+    "@bigtest/react": "latest",
     "babel-loader": "^8.0.0-beta.2",
     "css-loader": "^0.28.11",
     "highlight.js": "^9.12.0",

--- a/source/docs/index.html.erb
+++ b/source/docs/index.html.erb
@@ -7,6 +7,7 @@ title: API Docs
 <ul>
   <li><%= link_to '@bigtest/convergence', '/docs/convergence/' %></li>
   <li><%= link_to '@bigtest/interactor', '/docs/interactor/' %></li>
+  <li><%= link_to '@bigtest/react', '/docs/react/' %></li>
 </ul>
 
 <hr/>

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,19 +504,21 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@bigtest/convergence@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.7.0.tgz#df577d7e78b453cf80b4f29acf66dd7f60fcc0c1"
-
-"@bigtest/convergence@latest":
+"@bigtest/convergence@^0.9.1", "@bigtest/convergence@latest":
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.9.1.tgz#ddbe3e85e757b8fb82b80df95ed2e574c9d24429"
 
 "@bigtest/interactor@latest":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.4.4.tgz#a05b53515fbcb57bc8d47726d3f0b83398fa8552"
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.5.0.tgz#48b56c0706504d5c5652e1456302718522363120"
   dependencies:
-    "@bigtest/convergence" "^0.7.0"
+    "@bigtest/convergence" "^0.9.1"
+
+"@bigtest/react@latest":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@bigtest/react/-/react-0.1.1.tgz#7ff09a4c946857585af1d120e2073779de000c4c"
+  dependencies:
+    history "^4.7.2"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -3026,6 +3028,16 @@ highlight.js@^9.12.0:
   version "9.12.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -3221,7 +3233,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -3779,7 +3791,7 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -5263,6 +5275,10 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -6091,6 +6107,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
 vendors@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
@@ -6138,6 +6158,12 @@ vm-browserify@0.0.4:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
   dependencies:
     indexof "0.0.1"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.5.0:
   version "1.6.0"


### PR DESCRIPTION
Adds `@bigtest/react` to the API docs

Also ran `yarn upgrade` so that `@bigtest/interactor` and `@bigtest/convergence` docs are also updated.