### PR TITLE
General Improvements

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -14,10 +14,14 @@ activate :autoprefixer do |prefix|
   prefix.browsers = 'last 2 versions'
 end
 
+# Markdown rules
 set :markdown,
-  fenced_code_blocks: true,
   input: 'GFM',
+  fenced_code_blocks: true,
   hard_wrap: false
+
+set :markdown_engine, nil
+Tilt.register FormattingHelpers::KramdownTemplate, 'md', 'markdown'
 
 # Dev-specific config
 configure :development do
@@ -47,8 +51,7 @@ end
 activate :external_pipeline,
   name: :js_css,
   command: "yarn #{build? ? 'build' : 'start'}",
-  source: './tmp',
-  latency: 2
+  source: './tmp'
 
 # Misc helpers
 helpers do

--- a/lib/formatting_helpers.rb
+++ b/lib/formatting_helpers.rb
@@ -1,9 +1,19 @@
 # Adds helpers for formatting content
 class FormattingHelpers < Middleman::Extension
+  # ensures the last n words are not widowed
+  def self.no_widow(text, count = 2)
+    return unless text
+    words = text.split(' ')
+    return text unless words.length > 1
+    beginwords = words[0, words.length - count].join(' ')
+    endwords = words[0 - count, count].join('&nbsp;')
+    "#{beginwords} #{endwords}"
+  end
+
+  # .erb formatting helpers
   helpers do
     def markdown(text)
       return unless text
-
       Kramdown::Document
         .new(text, config[:markdown]).to_html
         .gsub(%r{(<(p|li)>)(\X*?)(</\2>)}) { $1 + no_widow($3) + $4 }
@@ -15,14 +25,26 @@ class FormattingHelpers < Middleman::Extension
       no_widow Kramdown::Document.new(text, md_conf).to_html
     end
 
-    # ensures the last n words are not widowed
-    def no_widow(text, count = 2)
-      return unless text
-      words = text.split(' ')
-      return text unless words.length > 1
-      beginwords = words[0, words.length - count].join(' ')
-      endwords = words[0 - count, count].join('&nbsp;')
-      "#{beginwords} #{endwords}"
+    def no_widow(*args)
+      FormattingHelpers.no_widow(*args)
+    end
+  end
+
+  # Custom tilt template
+  class KramdownTemplate < ::Tilt::KramdownTemplate
+    def initialize(*args, &block)
+      super
+      @context = @options[:context] if @options.key?(:context)
+    end
+
+    def evaluate(context, *)
+      Kramdown::Converter::Custom.scope = @context || context
+
+      @output ||= begin
+        output, warnings = Kramdown::Converter::Custom.convert(@engine.root, @engine.options)
+        @engine.warnings.concat(warnings)
+        output
+      end
     end
   end
 end
@@ -34,6 +56,23 @@ module Kramdown
       def initialize(source, options)
         super
         @block_parsers = []
+      end
+    end
+  end
+
+  module Converter
+    # Kramdown converter that prevents widows
+    class Custom < Html
+      cattr_accessor :scope
+
+      def convert_p(el, indent)
+        content = FormattingHelpers.no_widow inner(el, indent)
+
+        if el.options[:transparent]
+          content
+        else
+          format_as_block_html(el.type, el.attr, content, indent)
+        end
       end
     end
   end

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -15,8 +15,12 @@
   </h2>
 
   <div class="home-hero-cta">
-    <%= link_to 'Quick Start', '/guides/quick-start.html', {
-      class: 'btn btn--secondary btn--hollow'
+    <%= link_to 'Start Testing Big', '/guides/quick-start.html', {
+      class: 'btn btn--secondary'
+    } %>
+
+    <%= link_to 'Chat on Gitter', 'https://gitter.im/bigtestjs', {
+      class: 'btn btn--primary btn--hollow'
     } %>
   </div>
 </section>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -20,6 +20,7 @@
 
     <title><%= ['BigTest', current_page.data.title].compact.join(' - ') %></title>
     <%= stylesheet_link_tag 'app' %>
+    <%= stylesheet_link_tag 'https://use.fontawesome.com/releases/v5.0.13/css/all.css' %>
     <%= stylesheet_link_tag 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-dark.min.css' %>
   </head>
   <body>

--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -12,17 +12,17 @@
     <div class="footer-sitemap-section">
       <h5>Community</h5>
       <a href="https://twitter.com/thefrontside">
-        <i class="fab fa-twitter"></i> Twitter
+        <i class="fab fa-fw fa-twitter"></i> Twitter
       </a>
-      <a href="https://gitter.im/thefrontside/bigtest">
-        Gitter chat
+      <a href="https://gitter.im/bigtestjs">
+        <i class="fab fa-fw fa-gitter"></i> Gitter
       </a>
     </div>
 
     <div class="footer-sitemap-section">
       <h5>More</h5>
       <a href="https://github.com/bigtestjs">
-        <i class="fab fa-github"></i> Github
+        <i class="fab fa-fw fa-github"></i> Github
       </a>
       <a href="https://fronstide.io">Frontside</a>
     </div>

--- a/source/partials/doc/_class.erb
+++ b/source/partials/doc/_class.erb
@@ -1,5 +1,5 @@
-<div id="/<%= doc.longname %>" class="<%= doc_classes doc %>">
-  <h2 class="doc-title">
+<div class="<%= doc_classes doc %>">
+  <h2 class="doc-title" id="/<%= doc.longname %>">
     <em>new</em> <%= doc.name %>
     <span class="doc-title-args">
       (<em><%= doc.params.map(&:name).join(', ') %></em>)

--- a/source/partials/doc/_function.erb
+++ b/source/partials/doc/_function.erb
@@ -1,5 +1,5 @@
-<div id="/<%= doc.longname %>" class="<%= doc_classes doc %>">
-  <% content_tag (doc.memberof ? :h3 : :h2), class: 'doc-title' do %>
+<div class="<%= doc_classes doc %>">
+  <% content_tag (doc.memberof ? :h3 : :h2), class: 'doc-title', id: "/#{doc.longname}" do %>
     <%= doc.name %>
 
     <span class="doc-title-args">

--- a/source/partials/doc/_member.erb
+++ b/source/partials/doc/_member.erb
@@ -1,5 +1,5 @@
-<div id="/<%= doc.longname %>" class="<%= doc_classes doc %>">
-  <% content_tag (doc.memberof ? :h3 : :h2), class: 'doc-title' do %>
+<div class="<%= doc_classes doc %>">
+  <% content_tag (doc.memberof ? :h3 : :h2), class: 'doc-title', id: "/#{doc.longname}" do %>
     <%= doc.name %>
 
     <% if doc.type.present? %>

--- a/source/stylesheets/base/_common.scss
+++ b/source/stylesheets/base/_common.scss
@@ -30,3 +30,22 @@ nav ul {
   position: absolute !important;
   width: 1px;
 }
+
+/* Normally, the header covers any target on the page. This shifts the
+   active target down below the header so it is completely visible */
+[id]:target {
+  position: static;
+  pointer-events: none;
+
+  &::before {
+    content: '';
+    display: block;
+    height: $space-med-lg;
+    margin-top: -$space-med-lg;
+    visibility: hidden;
+  }
+
+  & > * {
+    pointer-events: auto;
+  }
+}

--- a/source/stylesheets/components/_button.scss
+++ b/source/stylesheets/components/_button.scss
@@ -2,9 +2,8 @@
   border-radius: 0.5rem;
   box-shadow: $shadow-medium;
   display: inline-block;
-  height: $space-med-sm;
-  line-height: $space-med-sm;
-  padding: 0 $space-small;
+  padding: $space-xxs $space-small;
+  transition: background-color 100ms ease-in-out;
   font-weight: 600;
 
   &--primary {
@@ -13,6 +12,14 @@
 
     &.btn--hollow {
       color: $color-primary;
+
+      &:hover {
+        background-color: $color-primary-light;
+      }
+    }
+
+    &:hover {
+      background-color: $color-primary-dark;
     }
   }
 
@@ -22,6 +29,14 @@
 
     &.btn--hollow {
       color: $color-secondary;
+
+      &:hover {
+        background-color: $color-secondary-lighter;
+      }
+    }
+
+    &:hover {
+      background-color: $color-secondary-dark;
     }
   }
 
@@ -29,5 +44,9 @@
     background-color: transparent;
     box-shadow: none;
     border: 1px solid;
+  }
+
+  &:hover {
+    text-decoration: none;
   }
 }

--- a/source/stylesheets/pages/_home.scss
+++ b/source/stylesheets/pages/_home.scss
@@ -41,9 +41,11 @@
   }
 
   &-logo {
-    width: 100%;
+    border-bottom: none;
     margin-bottom: $space-med-sm;
     max-width: 40rem;
+    padding-bottom: 0;
+    width: 100%;
 
     img {
       display: block;
@@ -74,7 +76,14 @@
   }
 
   &-cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     margin-bottom: $space-med-sm;
+
+    a {
+      margin-bottom: $space-xs;
+    }
   }
 }
 

--- a/source/stylesheets/utilities/_variables.scss
+++ b/source/stylesheets/utilities/_variables.scss
@@ -11,8 +11,12 @@ $size-xxl: 2rem;
 
 $color-primary: #26abe8;
 $color-primary-light: lighten($color-primary, 40%);
+$color-primary-lighter: lighten($color-primary, 44%);
+$color-primary-dark: darken($color-primary, 5%);
 $color-secondary: #f74d7b;
 $color-secondary-light: lighten($color-secondary, 30%);
+$color-secondary-lighter: lighten($color-secondary, 33%);
+$color-secondary-dark: darken($color-secondary, 5%);
 $color-tertiary: #14315d;
 $color-tertiary-light: lighten($color-tertiary, 30%);
 $color-gray: #eeeef6;


### PR DESCRIPTION
## Purpose

While working on the guides, I went ahead and did a few other things

1. Added button hover effects
2. Fixed FontAwesome footer icons
3. Added our Gitter link to the home page hero (#39)
4. Use the `no_widow` helper for all markdown paragraphs
5. Adjust link targets to be below the fixed header (#33)

## Approach

1. Added a couple variables and hover styles
2. Added FontAwesome styles from their CDN and made our icons fixed-width
3. Changed the home quick-start button and added a Gitter button
4. Created a custom Kramdown converter that removes widows from all paragraphs
5. For URL targets, used a pseudo element with height and negative margin greater than the header height to push the content below the header. This will work best with headings that do not contain their own pseudo elements, so this might be an edge case in the future. To prevent the pseudo element from covering elements above the heading, `pointer-events: none` is toggled for the targeted element.