### PR TITLE
Add Interactor Guides

### DIFF
--- a/data/sidebars.yml
+++ b/data/sidebars.yml
@@ -4,3 +4,16 @@ guides:
       - title: Getting Started
         url: /guides/getting-started.html
 
+  - title: Interactors
+    links:
+      - title: Introduction
+        url: /guides/interactors/introduction.html
+
+      - title: Custom Interactors
+        url: /guides/interactors/custom-interactors.html
+
+      - title: Composing Interactors
+        url: /guides/interactors/composing-interactors.html
+
+      - title: Available Interactions
+        url: /guides/interactors/available-interactions.html

--- a/data/sidebars.yml
+++ b/data/sidebars.yml
@@ -1,6 +1,6 @@
 guides:
-  - title: Introduction
-    url: /guides/intro.html
+  - title: Testing Big
+    links:
+      - title: Getting Started
+        url: /guides/getting-started.html
 
-  - title: Quick Start
-    url: /guides/quick-start.html

--- a/source/docs/index.html.erb
+++ b/source/docs/index.html.erb
@@ -10,8 +10,6 @@ title: API Docs
   <li><%= link_to '@bigtest/react', '/docs/react/' %></li>
 </ul>
 
-<hr/>
-
 <%= partial 'partials/quest-issue', locals: {
   issue_number: 26
 } %>

--- a/source/guides/getting-started.html.erb
+++ b/source/guides/getting-started.html.erb
@@ -1,0 +1,9 @@
+---
+title: Getting Started
+---
+
+<h1>Getting Started</h1>
+
+<%= partial 'partials/quest-issue', locals: {
+  issue_number: 14
+} %>

--- a/source/guides/index.html.erb
+++ b/source/guides/index.html.erb
@@ -4,6 +4,18 @@ title: Guides
 
 <h1>Introduction</h1>
 
+<h2>Guides</h2>
+
+<% data.sidebars.guides.each do |item| %>
+  <h3><%= item[:title] %></h3>
+
+  <ul>
+    <% item[:links].each do |li| %>
+      <li><%= link_to li[:title], li[:url] %></li>
+    <% end %>
+  </ul>
+<% end %>
+
 <%= partial 'partials/quest-issue', locals: {
   issue_number: 18
 } %>

--- a/source/guides/index.html.erb
+++ b/source/guides/index.html.erb
@@ -1,9 +1,9 @@
 ---
-title: Quick Start
+title: Guides
 ---
 
-<h1>Quick Start</h1>
+<h1>Introduction</h1>
 
 <%= partial 'partials/quest-issue', locals: {
-  issue_number: 14
+  issue_number: 18
 } %>

--- a/source/guides/interactors/available-interactions.html.md
+++ b/source/guides/interactors/available-interactions.html.md
@@ -1,0 +1,194 @@
+---
+title: Guides | Interactors | Available Interactions
+prev_guide:
+  title: Composing Interactors
+  url: /guides/interactors/composing-interactors.html
+---
+
+# Available Interactions
+
+Below is a brief description of the various interactions available
+out-of-the-box with interactors. Clicking the name of an interaction
+will take you to the corresponding API docs which include more details
+and examples.
+
+## Default Interactions
+
+These default interaction properties and methods are available on all
+[interactors](/guides/interactors/introduction/), but may be safely
+overwritten when defining your own, custom, interactors.
+
+### Properties
+
+All properties, with the exception of `isPresent`, will throw an error
+if the element cannot be located within the interactor's root element.
+
+- **[`#text`](/docs/interactor/#/Interactor#text)** <br/>
+  Returns the trimmed `textContent` property of an element.
+
+- **[`#value`](/docs/interactor/#/Interactor#value)** <br/>
+  Returns the `value` property of an element.
+
+- **[`#isVisible`](/docs/interactor/#/Interactor#isVisible)** <br/>
+  Returns `true` or `false` if an element is visible in the document.
+
+- **[`#isHidden`](/docs/interactor/#/Interactor#isHidden)** <br/>
+  Returns `true` or `false` if an element _exists_ in the document but
+  is visually hidden.
+
+- **[`#isPresent`](/docs/interactor/#/Interactor#isPresent)** <br/>
+  Returns `true` or `false` if an element can be found within the
+  document.
+
+### Methods
+
+All default interactor methods accept an optional selector as the
+first argument. Given a selector, the interaction will be made on the
+matching element within the parent interactor's root element.
+
+_Note: Interaction methods return new instances of the interactor and
+do not preform any interactions until the `#run()` method is invoked
+on the new instance._
+
+- **[`#click([selector])`](/docs/interactor/#/Interactor#click)** <br/>
+  Triggers a `click` event on an element.
+
+- **[`#fill([selector], value)`](/docs/interactor/#/Interactor#fill)** <br/>
+  Changes the `value` of an element and triggers `input` and `change`
+  events.
+
+- **[`#select([selector], option)`](/docs/interactor/#/Interactor#select)** <br/>
+  Selects an option by it's `text` value and triggers `input` and
+  `change` events.
+
+- **[`#focus([selector])`](/docs/interactor/#/Interactor#focus)** <br/>
+  Triggers a `focus` event on an element.
+
+- **[`#blur([selector])`](/docs/interactor/#/Interactor#blur)** <br/>
+  Triggers a `blur` event on an element.
+
+- **[`#scroll([selector], { top, left })`](/docs/interactor/#/Interactor#scroll)** <br/>
+  Sets an element's `scrollTop` and `scrollLeft` properties and
+  triggers a `scroll` event. The `top` and `left` values specify how
+  many pixels in that direction to scroll to; at least one direction
+  must be specified.
+
+- **[`#trigger([selector], name[, options])`](/docs/interactor/#/Interactor#trigger)** <br/>
+  Triggers an arbitrary event, `name`, on an element with any
+  specified event `options`. By default, the `bubbles` and
+  `cancelable` options are set to `true`.
+
+## Property Creators
+
+Property creators can be utilized when [creating your own custom
+interactors](/guides/interactors/custom-interactors/) using the
+`@interactor` class decorator. The creator functions accept an
+optional selector just like the default methods do. However, the
+resulting instance methods _do not_ have an optional selector
+argument.
+
+### Properties
+
+Creators for interactor properties return getters that are lazily
+evaluated. Just like the default properties, with the exception of
+`isPresent`, all properties will throw an error if the element cannot
+be located within the interactor's root element.
+
+- **[`text([selector])`](/docs/interactor/#/text)** <br/>
+  Returns the trimmed `textContent` property of an element.
+
+- **[`value([selector])`](/docs/interactor/#/value)** <br/>
+  Returns the `value` property of an element.
+
+- **[`isVisible([selector])`](/docs/interactor/#/isVisible)** <br/>
+  Returns `true` or `false` if an element is visible in the document.
+
+- **[`isHidden([selector])`](/docs/interactor/#/isHidden)** <br/>
+  Returns `true` or `false` if an element _exists_ in the document but
+  is visually hidden.
+
+- **[`isPresent([selector])`](/docs/interactor/#/isPresent)** <br/>
+  Returns `true` or `false` if an element can be found within the
+  document.
+
+- **[`attribute([selector], attr)`](/docs/interactor/#/attribute)** <br/>
+  Returns the specified attribute of an element via `getAttribute`.
+
+- **[`property([selector], prop)`](/docs/interactor/#/property)** <br/>
+  Returns the specified property value of an element.
+
+- **[`hasClass([selector], className)`](/docs/interactor/#/hasClass)** <br/>
+  Returns `true` or `false` if an element's `classList` contains
+  the specified classname.
+
+- **[`is([selector], match)`](/docs/interactor/#/is)** <br/>
+  Returns `true` or `false` if an element can be selected by the
+  specified matching selector via `Element.matches()`.
+
+### Methods
+
+Creators for interactor methods return chainable functions that then
+return new instances with the specific interaction added to it's
+queue. The interactions are not run until the interactor's `#run()`
+method is invoked, or when using the `async`/`await` syntax.
+
+- **[`clickable([selector]) => click()`](/docs/interactor/#/clickable)** <br/>
+  Triggers a `click` event on an element.
+
+- **[`fillable([selector]) => fill(value)`](/docs/interactor/#/fillable)** <br/>
+  Changes the `value` of an element and triggers `input` and `change`
+  events.
+
+- **[`selectable([selector]) => select(option)`](/docs/interactor/#/selectable)** <br/>
+  Selects an option by it's `text` value and triggers `input` and
+  `change` events.
+
+- **[`focusable([selector]) => focus()`](/docs/interactor/#/focusable)** <br/>
+  Triggers a `focus` event on an element.
+
+- **[`blurrable([selector]) => blur()`](/docs/interactor/#/blurrable)** <br/>
+  Triggers a `blur` event on an element.
+
+- **[`scrollable([selector]) => scroll({ top, left })`](/docs/interactor/#/scrollable)** <br/>
+  Sets an element's `scrollTop` and `scrollLeft` properties and
+  triggers a `scroll` event. The `top` and `left` values specify how
+  many pixels in that direction to scroll to; at least one direction
+  must be specified.
+
+- **[`triggerable([selector], name[, options]) => trigger([options])`](/docs/interactor/#/triggerable)** <br/>
+  Triggers an arbitrary event, `name`, on an element with any
+  specified event `options`. By default, the `bubbles` and
+  `cancelable` options are set to `true`. The two `options` arguments
+  are merged when the interactor is run.
+
+### Interactors
+
+[Nested interactor](/guides/interactors/composing-interactors/)
+creators return interactor instances scoped to the parent interactor's
+root element. The second argument is an optional hash of additional
+interactor properties to add to the returned interactor. The second
+argument may also be an interactor class with it's own methods and
+properties used when creating the nested, scoped, interactor.
+
+- **[`scoped(selector[, properties])`](/docs/interactor/#/scoped)** <br/>
+  Interactor creator for a single nested interactor.
+
+- **[`collection(selector[, properties]) => fn([index])`](/docs/interactor/#/collection)** <br/>
+  Interaction creator for a collection of nested interactors. A
+  collection interaction takes an index as it’s argument and returns
+  an interactor scoped to that element. Without an index, an array of
+  corresponding interactors are returned
+
+### Helpers
+
+Property creator helpers may be used to define your own [custom
+interactions](/guides/interactors/custom-interactors/#custom-interaction-creators).
+Defining methods and getters directly on an interactor class is
+supported. However, using these helpers allows you to create reusable
+property creators like the above interactions.
+
+- **[`computed(getter)`](/docs/interactor/#/computed)** <br/>
+  Returns a property descriptor for an interactor property.
+
+- **[`action(method)`](/docs/interactor/#/action)** <br/>
+  Returns a property descriptor for an interactor method.

--- a/source/guides/interactors/composing-interactors.html.md
+++ b/source/guides/interactors/composing-interactors.html.md
@@ -1,0 +1,107 @@
+---
+title: Guides | Interactors | Composing Interactors
+prev_guide:
+  title: Custom Interactors
+  url: /guides/interactors/custom-interactors.html
+next_guide:
+  title: Available Interactions
+  url: /guides/interactors/available-interactions.html
+---
+
+# Composing Interactors
+
+When defining custom interactors, you may create more complicated
+interactors by composing smaller ones. By default, nested interactors
+_are not_ scoped to their parent interactor. This is because there can
+be situations, like a modal or popover, where the element has been
+appended to a different part of the document.
+
+``` javascript
+@interactor class ModalInteractor {
+  // ...
+}
+
+@interactor class SignUpFormInteractor {
+  // the default scope is used when a new instance's selector is omitted
+  static defaultScope = '[data-test-sign-up-form]';
+
+  // the modal element exists outside of the form
+  confirmation = new ModalInteractor('[data-test-modal]');
+
+  // ...
+}
+```
+
+## Scoped Interactors
+
+With the `scoped` property creator, you can create nested interactors
+that are scoped _within the parent interactor_. The second argument
+allows us to specify additional nested properties or even another
+interactor class entirely.
+
+``` javascript
+@interactor class SignUpFormInteractor {
+  // ...
+
+  // scoped interactors look for an element within the parent element
+  submit = scoped('[data-test-submit]');
+
+  // a hash of other properties may be provided as the second argument
+  email = scoped('[data-test-email-field] input', {
+    placeholder: property('placeholder')
+  });
+
+  // using a class is preferred for maximum composability
+  password = scoped('[data-test-password-field]', FieldInteractor);
+}
+```
+
+The `collection` property creator returns a function that accepts an
+index and will return a nested interactor for an element at that
+index. This interactor is lazy just like normal interactors and will
+not attempt to find the element at the index until interactions run or
+properties are accessed. When given no arguments, the collection
+function will return an array of interactors; one for every matching
+element found at the time it was invoked.
+
+``` javascript
+@interactor class SignUpFormInteractor {
+  // ...
+
+  // collections also accept additional properties or a class as the second argument
+  interests = collection('[data-test-interests-item]"]', {
+    toggle: click('input[type="checkbox"]'),
+    label: text('[data-test-label]')
+  });
+}
+```
+
+## Nested Methods and Properties
+
+Nested interactor methods, scoped or not, return instances of the root
+interactor for additional chaining. Nested properties are still lazily
+evaluated at the time they're accessed.
+
+``` javascript
+let signUp = new SignUpFormInteractor();
+
+// `await` will immediately invoke `#run()`, we could also save a reference
+// to this specific interaction to re-use elsewhere
+await signUp
+  .email.fill('foo@bar.baz')
+  .password.fillIn('53cr3t')
+  .interests(3).toggle()
+  .submit();
+
+// nested interactors may be broken from the parent chain using `#only()`
+await signUp.email.only()
+  .focus()
+  .fill('foo@bar')
+  .blur();
+
+// nested properties may throw one of a few "element not found" errors
+signUp.interests(10).label
+// => Error: unable to find "[data-test-label]"
+// => Error: unable to find "[data-test-interest-item]" at index 10
+// => Error: unable to find "[data-test-sign-up-form]"
+```

--- a/source/guides/interactors/custom-interactors.html.md
+++ b/source/guides/interactors/custom-interactors.html.md
@@ -1,0 +1,174 @@
+---
+title: Guides | Interactors | Custom Interactors
+prev_guide:
+  title: Introduction
+  url: /guides/interactors/introduction.html
+next_guide:
+  title: Composing Interactors
+  url: /guides/interactors/composing-interactors.html
+---
+
+# Custom Interactors
+
+While using the default Interactor can be fine for simple and smaller
+components, custom interactors are easy to create using the class
+decorator and interaction creators. Custom interactors allow us to
+keep all of our selectors in one place, and have the benefit of being
+composable with other interactors to interact with more complex
+structures.
+
+``` javascript
+import {
+  interactor,
+  text,
+  value,
+  property,
+  fillable,
+  focusable,
+  blurrable
+} from '@bigtest/interactor';
+
+@interactor class FieldInteractor {
+  // custom properties are lazy like the default properties
+  label = text('[data-test-label]');
+  value = value('[data-test-input]');
+  type = property('[data-test-input]', 'type');
+
+  // `*able` property creators create chainable interactor methods
+  fill = focusable('[data-test-input]');
+  focus = focusable('[data-test-input]');
+  blur = blurrable('[data-test-input]');
+}
+```
+
+The default set of properties and methods have corresponding
+interaction creators. There are also several other [available
+interaction creators](/guides/interactors/available-interactions/#property-creators)
+to choose from as well.
+
+## Custom Methods And Properties
+
+Additional methods and property getters can also be defined directly
+on the decorated class. However, be careful with property initializers
+and using `this`, as it will reference the undecorated class instance
+and **not** the interactor instance you might expect.
+
+``` javascript
+@interactor class FieldInteractor {
+  // ...
+
+  // methods that return new instances of itself will be chainable with other methods
+  fillIn(value) {
+    return this.focus().fill(value).blur()
+  }
+
+  // using getters ensures that properties will not be invoked until necessary
+  get isPassword() {
+    return this.type === 'password';
+  }
+
+  // the following will not work because `this` references the undecorated class
+  // foo = () => this.doesntWork()
+}
+```
+
+## Custom Interaction Creators
+
+For commonly used custom properties and methods, two helpers exist
+which allow you to define your own reusable interaction creators:
+`computed`, for properties, and `action`, for methods.
+
+In addition to the default methods, interactors also have a few of
+their own helper methods.
+
+- `this.$(selector)` uses the interactor's root element and
+  `querySelector` to look up nested elements. When the element cannot
+  be found, an error is thrown; when `selector` is not defined, the
+  root element is returned instead.
+
+- `this.$$(selector)` also uses the interactor's root element, but uses
+  `querySelectorAll` and returns an array of matching elements. An
+  error will only be thrown if the root element cannot be found.
+
+``` javascript
+import { computed } from '@bigtest/interactor';
+
+// returns a specific data attribute of an element
+export function data(selector, key) {
+  // to align with other interaction creators, `selector` is optional
+  if (!key) {
+    key = selector;
+    selector = null;
+  }
+
+  // the `computed` helper creates a getter
+  return computed(function() {
+    return this.$(selector).dataset[key];
+  });
+}
+```
+
+Interactor methods `#find(selector)` and `#findAll(selector)` behave
+just like their aforementioned counterparts, except that they return
+new instances for chaining. The found element(s) are passed along to
+the next function in the chain.
+
+``` javascript
+import { action } from '@bigtest/interactor';
+
+// triggers a keypress event for each character in a given string
+export function typeable(selector) {
+  // the `action` helper returns an interactor method
+  return action(function(string) {
+    return this.find(selector)
+    // `#do` executes a callback within the queue
+      .do(($node) => {
+        for (let char of string) {
+          $node.dispatchEvent(
+            new Event('keypress', {
+              charChode: char.charCodeAt(),
+              cancelable: true,
+              bubbles: true
+            })
+          );
+        }
+      });
+  });
+}
+```
+
+## Using Custom Interactors
+
+Custom interactors can be used just like normal interactors would be.
+
+``` javascript
+let username = new FieldInteractor('[data-test-username-field]');
+let password = new FieldInteractor('[data-test-password-field]');
+
+// focuses, fills, and blurs the field input
+await username.fillIn('bigtester');
+
+// property access could trigger "element not found" errors like default properties
+expect(username.type).to.equal('text');
+expect(password.isPassword).to.be.true;
+```
+
+If an interactor typically only ever belongs to one element, defining
+a static `defaultScope` property prevents us from having to initialize
+the interactor with a scope selector every time.
+
+``` javascript
+@interactor class HomePageInteractor() {
+  static defaultScope = '[data-test-home-page]';
+  // ...
+}
+
+// defaults scope to "[data-test-home-page]"
+let homePage = new HomePageInteractor();
+```
+
+Custom Interactors can also be used to [compose other
+interactors](/guides/interactors/composing-interactors/) by nesting
+them within each other. Helpers like `scoped` and `collection` also
+allow you to scope an interactor or group of interactors to specific
+elements within the parent interactor.

--- a/source/guides/interactors/introduction.html.md
+++ b/source/guides/interactors/introduction.html.md
@@ -1,0 +1,98 @@
+---
+title: Guides | Interactors | Introduction
+next_guide:
+  title: Custom Interactors
+  url: /guides/interactors/custom-interactors.html
+---
+
+# Interactors
+
+In biology, an interactor is defined as part of an organism that
+natural selection acts upon. A BigTest interactor defines part of an
+app that tests act upon. You can think of interactors as composable
+[page objects](https://martinfowler.com/bliki/PageObject.html) for
+modern components.
+
+``` javascript
+import { Interactor } from '@bigtest/interactor';
+
+// an interactor can be scoped directly to an element
+let input = new Interactor('[data-test-input]');
+let submit = new Interactor('[data-test-submit]');
+```
+
+## Interactor Properties
+
+Interactor properties are lazy, and do not look up the element or
+property until accessed. If the element cannot be found, an error is
+thrown. This can be more useful than typical expectation failures
+because we know _why_ the expectation is failing instead of just
+knowing that the expectation failed with an incorrect value.
+
+``` javascript
+// when the elements do not exist in the DOM
+input.value //=> Error: unable to find "[data-test-input]"
+submit.text //=> Error: unable to find "[data-test-submit]"
+
+// when the elements do exist in the DOM
+input.value //=> "foo"
+submit.text //=> "Submit"
+```
+
+## Immutable Methods
+
+Interactors are immutable. Methods return new instances of the
+interactor with an additional interaction appended to it's queue. You
+can then run all of the interactions in an interactor's queue by
+calling the `#run()` method.
+
+``` javascript
+// this does not actually focus the input yet
+let focusInput = input.focus();
+
+// chaining additional interactions will add to the new instance queue
+let focusAndFill = focusInput.fill('some value');
+
+// an interactor will wait until the element exists before interacting with it
+focusAndFill.run()
+  .then(...)  // the input was succesfully focused and filled with "some value"
+  .catch(...) // something went wrong, likely the input was not found
+```
+
+Interactors can also be combined with each other to produce more
+complex interactions. And since they're immutable, they can be reused
+over and over again.
+
+``` javascript
+// remember, this does not actually interact with the elements yet
+let fillInput = input.focus().fill('some value').blur();
+let submitForm = submit.click();
+
+// when this is run, it will focus, fill, and blur the input
+// before finally clicking on the submit button
+let fillAndSubmit = fillInput.append(submitForm);
+
+// in one test...
+fillAndSubmit.run()
+// ... in another
+fillAndSubmit.run()
+```
+
+The default interaction methods optionally accept a selector as their
+first argument so that you may interact with elements within the
+scoped interactor. Interactors are also thennable, which immediately
+invokes `#run()`, allowing interactors to work with the
+`async`/`await` syntax.
+
+``` javascript
+await new Interactor('[data-test-form]')
+  .fill('[data-test-input]', 'some value')
+  .click('[data-test-submit]');
+```
+
+For available default properties and methods, see [Available
+Interactions](/guides/interactors/available-interactions/). You may
+overwrite or define your own interactions by creating a [custom
+interactor](/guides/interactors/custom-interactors/). This can be done
+either by extending the `Interactor` class directly, or by using the
+`@interactor` class decorator and interaction creators.

--- a/source/guides/intro.html.erb
+++ b/source/guides/intro.html.erb
@@ -1,9 +1,0 @@
----
-title: Introduction
----
-
-<h1>Introduction</h1>
-
-<%= partial 'partials/quest-issue', locals: {
-  issue_number: 18
-} %>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -15,7 +15,7 @@
   </h2>
 
   <div class="home-hero-cta">
-    <%= link_to 'Start Testing Big', '/guides/quick-start.html', {
+    <%= link_to 'Start Testing Big', '/guides/getting-started.html', {
       class: 'btn btn--secondary'
     } %>
 

--- a/source/layouts/guide.erb
+++ b/source/layouts/guide.erb
@@ -1,3 +1,6 @@
+<% has_prev_guide = current_page.data.respond_to? 'prev_guide' %>
+<% has_next_guide = current_page.data.respond_to? 'next_guide' %>
+
 <% wrap_layout :layout do %>
   <%= partial 'partials/sidebar', locals: {
     title: 'Guides',
@@ -6,5 +9,37 @@
 
   <article class="main-content">
     <%= yield %>
+
+    <% if has_prev_guide || has_next_guide %>
+      <footer class="guides-footer">
+        <% if has_prev_guide %>
+          <div class="guides-footer--prev">
+            <% link_to current_page.data.prev_guide.url, {
+              :class => 'btn btn--secondary btn--hollow'
+            } do %>
+              <svg viewbox="0 0 100 100">
+                <path d="M75,0L25,50L75,100"/>
+              </svg>
+
+              <%= current_page.data.prev_guide.title %>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if has_next_guide %>
+          <div class="guides-footer--next">
+            <% link_to current_page.data.next_guide.url, {
+              :class => 'btn btn--secondary btn--hollow'
+            } do %>
+              <%= current_page.data.next_guide.title %>
+
+              <svg viewbox="0 0 100 100">
+                <path d="M25,0L75,50L25,100">
+              </svg>
+            <% end %>
+          </div>
+        <% end %>
+      </footer>
+    <% end %>
   </article>
 <% end %>

--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -5,7 +5,7 @@
         <img src="/images/logo-white.svg" alt="BigTest">
       </a>
 
-      <%= link_to 'Guides', '/guides/intro.html' %>
+      <%= link_to 'Guides', '/guides/index.html' %>
       <%= link_to 'Docs', '/docs/index.html' %>
     </div>
 

--- a/source/partials/_header.erb
+++ b/source/partials/_header.erb
@@ -8,7 +8,7 @@
 
     <nav class="header-nav">
       <ul>
-        <li><%= active_link_to 'Guides', '/guides/intro.html', '/guides/' %></li>
+        <li><%= active_link_to 'Guides', '/guides/index.html', '/guides/' %></li>
         <li><%= active_link_to 'Docs', '/docs/index.html', '/docs/' %></li>
       </ul>
     </nav>

--- a/source/stylesheets/app.scss
+++ b/source/stylesheets/app.scss
@@ -14,3 +14,4 @@
 @import 'components/quest-issue';
 @import 'components/tabbed-layout';
 @import 'pages/home';
+@import 'pages/docs';

--- a/source/stylesheets/app.scss
+++ b/source/stylesheets/app.scss
@@ -15,3 +15,4 @@
 @import 'components/tabbed-layout';
 @import 'pages/home';
 @import 'pages/docs';
+@import 'pages/guides';

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -1,7 +1,9 @@
 h1 {
+  border-bottom: 1px solid $color-primary;
   font-size: $size-large;
   font-weight: 600;
   margin-bottom: $space-small;
+  padding-bottom: $space-xs;
 
   @media #{$media-medium-up} {
     font-size: $size-xxl;
@@ -12,6 +14,10 @@ h2 {
   font-size: $size-med-lg;
   font-weight: 700;
   margin-bottom: $space-small;
+
+  &:not(:first-child) {
+    margin-top: $space-med-sm;
+  }
 
   @media #{$media-medium-up} {
     font-size: $size-xl;
@@ -48,6 +54,11 @@ ul, ol, p {
   @media #{$media-medium-up} {
     font-size: $size-medium;
   }
+}
+
+ul {
+  list-style: disc;
+  padding-left: $space-small;
 }
 
 a {

--- a/source/stylesheets/components/_doc.scss
+++ b/source/stylesheets/components/_doc.scss
@@ -68,9 +68,8 @@
   }
 
   &-args {
-    list-style: disc;
-    padding-left: $space-small;
-    margin-bottom: $space-small;
+    list-style: none;
+    padding: 0;
 
     li {
       margin-bottom: $space-xxs;

--- a/source/stylesheets/components/_quest-issue.scss
+++ b/source/stylesheets/components/_quest-issue.scss
@@ -2,6 +2,7 @@
   background: $color-primary-light;
   border-radius: $space-xxs;
   padding: $space-med-sm;
+  margin-top: $space-medium;
   text-align: center;
 
   h2 {

--- a/source/stylesheets/layout/_sidebar.scss
+++ b/source/stylesheets/layout/_sidebar.scss
@@ -98,6 +98,10 @@
     }
   }
 
+  &-item &-list &-item.is-active a {
+    font-weight: 600;
+  }
+
   [aria-expanded="false"] + &-list,
   &-item:last-child &-list {
     border-bottom: none;

--- a/source/stylesheets/pages/_docs.scss
+++ b/source/stylesheets/pages/_docs.scss
@@ -1,0 +1,6 @@
+.docs:not(.docs_index) {
+  h1 {
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+}

--- a/source/stylesheets/pages/_guides.scss
+++ b/source/stylesheets/pages/_guides.scss
@@ -1,0 +1,46 @@
+.guides-footer {
+  border-top: 1px solid $color-primary;
+  padding-top: $space-med-sm;
+  margin-top: $space-med-lg;
+
+  &--prev {
+    float: left;
+    margin: 0 $space-xs $space-xs 0;
+
+    a {
+      padding-left: 2.5em;
+    }
+
+    svg {
+      left: 1em;
+    }
+  }
+
+  &--next {
+    float: right;
+    margin: 0 0 $space-xs $space-xs;
+
+    a {
+      padding-right: 2.5em;
+    }
+
+    svg {
+      right: 1em;
+    }
+  }
+
+  svg {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0.8em;
+    height: 0.8em;
+
+    path {
+      fill: none;
+      stroke: currentcolor;
+      stroke-width: 10;
+      stroke-linecap: round;
+    }
+  }
+}

--- a/source/stylesheets/pages/_home.scss
+++ b/source/stylesheets/pages/_home.scss
@@ -94,6 +94,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    list-style: none;
+    padding: 0;
 
     @media #{$media-medium-up} {
       flex-direction: row;
@@ -127,6 +129,8 @@
     flex-direction: column;
     align-items: center;
     margin-bottom: $space-small;
+    list-style: none;
+    padding: 0;
 
     @media #{$media-medium-up} {
       flex-direction: row;


### PR DESCRIPTION
## Purpose

_Adds interactor guides_

## Approach

Renamed the intro and quick start guides; the intro guide is now the index (which closes #16), and the quick start guide was renamed to "getting started" because it will eventually become "getting started in _\<insert popular framework here\>_".

Adjusted some styles so the guides look nice. The active sidebar sub-item is bold, level-1 headings have an underline (except for the API docs), added some top margin to level-2 headings, and added list styles and fixed the styles of the subsequent other lists.

Added some interactor guides! 😃Including links to other guides in the footer. I opted to use frontmatter instead of automating this with the sitemap because we will not want to lead a reader through some guides. For example, we wouldn't need to lead a reader through several "Getting Started with _\<Insert Popular Framework Here\>_" guides. We might also not want to lead a reader from one major section (like interactors) to another major section (like testing frameworks).

### Rendered Guides

- [Guides Index](https://bigtest-docs-pr-43.herokuapp.com/guides/)
- [Introduction](https://bigtest-docs-pr-43.herokuapp.com/guides/interactors/introduction/)
- [Custom Interactors](https://bigtest-docs-pr-43.herokuapp.com/guides/interactors/custom-interactors/)
- [Composing Interactors](https://bigtest-docs-pr-43.herokuapp.com/guides/interactors/composing-interactors/)
- [Available Interactors](https://bigtest-docs-pr-43.herokuapp.com/guides/interactors/available-interactors/)