### PR TITLE
Cache b-b-buster

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -32,6 +32,7 @@ end
 configure :build do
   activate :minify_css
   activate :minify_javascript
+  activate :asset_hash
 end
 
 # Pages

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "bigtest.js.org",
   "private": true,
   "scripts": {
-    "build": "webpack --bail -p",
-    "start": "webpack --watch -d"
+    "build": "webpack --env.production --bail -p",
+    "start": "webpack --env.development --watch -d"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,9 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const config = {
+module.exports = (env = {}) => ({
+  mode: env.production ? 'production' : 'development',
+
   entry: [
     './source/javascripts/index.js',
     './source/stylesheets/app.scss'
@@ -33,8 +35,6 @@ const config = {
     })
   ],
 
-  stats: 'errors-only',
-  devtool: 'inline-source-map'
-};
-
-module.exports = config;
+  devtool: env.development && 'inline-source-map',
+  stats: 'errors-only'
+});


### PR DESCRIPTION
## Purpose

After a recent release, the HTML was updated but the CSS was not until a hard refresh 

## Appraoch

#28 which was to activate the `asset_hash` option for middleman builds.

This caused a weird JSON error from the external pipeline. It was coming from `SourceMapConsumer`,  so I adjusted the webpack config to set the proper environment vars so sourcemaps are not generated in production. That silenced the error.