### PR TITLE
Fix JavaScript Syntax in interactor guide

### DIFF
--- a/source/guides/interactors/custom-interactors.html.md
+++ b/source/guides/interactors/custom-interactors.html.md
@@ -158,7 +158,7 @@ a static `defaultScope` property prevents us from having to initialize
 the interactor with a scope selector every time.
 
 ``` javascript
-@interactor class HomePageInteractor() {
+@interactor class HomePageInteractor {
   static defaultScope = '[data-test-home-page]';
   // ...
 }


### PR DESCRIPTION
Looks like there was a JavaScript typo so the class declaration syntax was off.