### PR TITLE
Add package name to docs title

### DIFF
--- a/lib/api_docs.rb
+++ b/lib/api_docs.rb
@@ -27,7 +27,8 @@ class APIDocs < Middleman::Extension
       {
         name: name,
         pkg: get_pkg(package),
-        docs: get_docs(package)
+        docs: get_docs(package),
+        title: get_docs(package)[0].longname,
       }
     end
   end

--- a/lib/api_docs.rb
+++ b/lib/api_docs.rb
@@ -28,7 +28,7 @@ class APIDocs < Middleman::Extension
         name: name,
         pkg: get_pkg(package),
         docs: get_docs(package),
-        title: get_docs(package)[0].longname,
+        title: "API Docs | #{name.capitalize}"
       }
     end
   end

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -18,7 +18,7 @@
     <meta name="msapplication-config" content="/images/favicon/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
 
-    <title><%= ['BigTest', current_page.data.title].compact.join(' - ') %></title>
+    <title><%= ['BigTest', current_page.data.title || locals['title']].compact.join(' - ') %></title>
     <%= stylesheet_link_tag 'app' %>
     <%= stylesheet_link_tag 'https://use.fontawesome.com/releases/v5.0.13/css/all.css' %>
     <%= stylesheet_link_tag 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-dark.min.css' %>


### PR DESCRIPTION
## What is this?

This will close #50 so now it will show that you're on the API docs & what package in the title. 

Shout out to @qpowell for doing pretty much all the work. This just pushes it over the finish line & will close out #51.

## Screenshots

**Before**
<img width="334" alt="image" src="https://user-images.githubusercontent.com/2072894/47052128-bc434b00-d16c-11e8-989c-b3f434ec95fe.png">

**After**

<img width="441" alt="image" src="https://user-images.githubusercontent.com/2072894/47052116-b2214c80-d16c-11e8-880d-1c33ac159f30.png">