### PR TITLE
Change gitter references to Discord

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -19,7 +19,7 @@
       class: 'btn btn--secondary'
     } %>
 
-    <%= link_to 'Chat on Gitter', 'https://gitter.im/bigtestjs', {
+    <%= link_to 'Chat on Discord', 'https://discord.gg/W7r24Aa', {
       class: 'btn btn--primary btn--hollow'
     } %>
   </div>

--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -14,8 +14,8 @@
       <a href="https://twitter.com/thefrontside">
         <i class="fab fa-fw fa-twitter"></i> Twitter
       </a>
-      <a href="https://gitter.im/bigtestjs">
-        <i class="fab fa-fw fa-gitter"></i> Gitter
+      <a href="https://discord.gg/W7r24Aa">
+        <i class="fab fa-fw fa-discord"></i> Discord
       </a>
     </div>
 


### PR DESCRIPTION
We'd like to move the bigtestjs Gitter to Discord - that's where React, Ember & Microstates are. I asked  to see if there are any objections to moving in Gitter. We'll see what people say. https://gitter.im/bigtestjs/Lobby?at=5c99562bd0133e21e515735d