### PR TITLE
Update chat link to point to Discord

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -19,7 +19,7 @@
       class: 'btn btn--secondary'
     } %>
 
-    <%= link_to 'Chat on Gitter', 'https://gitter.im/bigtestjs', {
+    <%= link_to 'Chat on Discord', 'https://discord.gg/RR6wfCr', {
       class: 'btn btn--primary btn--hollow'
     } %>
   </div>

--- a/source/partials/_footer.erb
+++ b/source/partials/_footer.erb
@@ -14,8 +14,8 @@
       <a href="https://twitter.com/thefrontside">
         <i class="fab fa-fw fa-twitter"></i> Twitter
       </a>
-      <a href="https://gitter.im/bigtestjs">
-        <i class="fab fa-fw fa-gitter"></i> Gitter
+      <a href="https://discord.gg/RR6wfCr">
+        <i class="fab fa-fw fa-discord"></i> Discord
       </a>
     </div>
 


### PR DESCRIPTION
Discord is where it all happens, so stop re-directing to a dead gitter channel